### PR TITLE
Cucumber tesztek ne fussanak

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,4 +59,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=BME-MIT-IET_iet-hf-2023-testing-titans
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=BME-MIT-IET_iet-hf-2023-testing-titans -Dtest=!RunCucumberTest


### PR DESCRIPTION
A Cucumber tesztek nem futnak GitHub Actions-el.
Szükségük van valamilyen window-ra, amit nem tudunk biztosítani.
Ezért kikapcsoltam.